### PR TITLE
feat: interfaz de gestion de terrenos en perfil de socio (frontend only)

### DIFF
--- a/src/app/core/services/terreno.service.ts
+++ b/src/app/core/services/terreno.service.ts
@@ -1,0 +1,35 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { environment } from '../../environments/environment.development';
+import { Observable } from 'rxjs';
+
+@Injectable({
+	providedIn: 'root',
+})
+export class TerrenoService {
+	private http = inject(HttpClient);
+	// Asegúrate de que tu compañero cree este endpoint en Django
+	private apiUrl = `${environment.apiUrl}/terrenos/`;
+
+	constructor() {}
+
+	// 1. Obtener terrenos de un socio específico
+	getTerrenosPorSocio(socioId: number): Observable<any[]> {
+		return this.http.get<any[]>(`${this.apiUrl}?socio_id=${socioId}`);
+	}
+
+	// 2. Crear un nuevo terreno
+	createTerreno(datos: any): Observable<any> {
+		return this.http.post<any>(this.apiUrl, datos);
+	}
+
+	// 3. Editar terreno (Para el futuro)
+	updateTerreno(id: number, datos: any): Observable<any> {
+		return this.http.put<any>(`${this.apiUrl}${id}/`, datos);
+	}
+
+	// 4. Eliminar terreno
+	deleteTerreno(id: number): Observable<any> {
+		return this.http.delete<any>(`${this.apiUrl}${id}/`);
+	}
+}

--- a/src/app/dashboard/pages/socios/detalle-socio/detalle-socio.component.html
+++ b/src/app/dashboard/pages/socios/detalle-socio/detalle-socio.component.html
@@ -45,7 +45,7 @@
 
 			<div class="grid grid-cols-1 md:grid-cols-3 gap-6 text-sm">
 				<div class="p-3 bg-gray-50 rounded-lg border border-gray-100">
-					<span class="block text-gray-500 font-medium mb-1">Barrio</span>
+					<span class="block text-gray-500 font-medium mb-1">Barrio (Domicilio)</span>
 					<span class="text-gray-800 font-bold text-base">{{ socio.barrio }}</span>
 				</div>
 				<div class="p-3 bg-gray-50 rounded-lg border border-gray-100">
@@ -65,10 +65,79 @@
 		</div>
 	</div>
 
+	<p-divider></p-divider>
+
+	<div class="mt-6 mb-8 animate-fade-in-up">
+		<div class="flex flex-col sm:flex-row justify-between items-start sm:items-center mb-4 gap-4">
+			<div>
+				<h3 class="text-xl font-bold text-gray-800 m-0">Propiedades Registradas</h3>
+				<p class="text-gray-500 text-sm">Administra los terrenos y medidores asignados a este socio.</p>
+			</div>
+
+			<p-button
+				label="Agregar Terreno"
+				icon="pi pi-plus"
+				[rounded]="true"
+				severity="primary"
+				(onClick)="abrirModalTerreno()"
+			>
+			</p-button>
+		</div>
+
+		<div class="card bg-white rounded-xl shadow-sm border border-gray-100 overflow-hidden">
+			<p-table [value]="terrenos" [tableStyle]="{ 'min-width': '50rem' }">
+				<ng-template pTemplate="header">
+					<tr>
+						<th>Barrio / Sector</th>
+						<th>Dirección / Referencia</th>
+						<th>Servicio (Medidor)</th>
+						<th class="text-center">Acciones</th>
+					</tr>
+				</ng-template>
+
+				<ng-template pTemplate="body" let-terreno>
+					<tr>
+						<td class="font-bold">{{ terreno.barrio }}</td>
+						<td>{{ terreno.direccion }}</td>
+						<td>
+							<p-tag
+								[severity]="terreno.tiene_medidor ? 'info' : 'warn'"
+								[value]="terreno.tiene_medidor ? '💧 Medidor: ' + terreno.codigo_medidor : '🚫 Solo Cometida'"
+								[rounded]="true"
+							>
+							</p-tag>
+						</td>
+						<td class="text-center">
+							<p-button
+								icon="pi pi-pencil"
+								[text]="true"
+								[rounded]="true"
+								severity="secondary"
+								pTooltip="Editar terreno"
+								tooltipPosition="top"
+							></p-button>
+						</td>
+					</tr>
+				</ng-template>
+
+				<ng-template pTemplate="emptymessage">
+					<tr>
+						<td colspan="4" class="text-center p-8">
+							<div class="flex flex-col items-center justify-center text-gray-400">
+								<i class="pi pi-home text-4xl mb-2"></i>
+								<p>Este socio aún no tiene terrenos registrados.</p>
+								<p class="text-sm">Haz clic en "Agregar Terreno" para registrar uno.</p>
+							</div>
+						</td>
+					</tr>
+				</ng-template>
+			</p-table>
+		</div>
+	</div>
+
 	<p-tabs value="0">
 		<p-tablist>
 			<p-tab value="0">Historial de Pagos</p-tab>
-			<p-tab value="1">Medidores</p-tab>
 		</p-tablist>
 
 		<p-tabpanels>
@@ -105,32 +174,6 @@
 					</ng-template>
 				</p-table>
 			</p-tabpanel>
-
-			<p-tabpanel value="1">
-				<p-table [value]="misMedidores" styleClass="p-datatable-sm" [rowHover]="true">
-					<ng-template pTemplate="header">
-						<tr>
-							<th>Código</th>
-							<th>Ubicación</th>
-							<th>Tipo</th>
-							<th>Estado</th>
-						</tr>
-					</ng-template>
-					<ng-template pTemplate="body" let-med>
-						<tr>
-							<td class="font-bold text-gray-800">{{ med.codigo }}</td>
-							<td>{{ med.ubicacion }}</td>
-							<td>
-								<span class="text-xs font-semibold px-2 py-1 rounded bg-blue-50 text-blue-600">{{ med.tipo }}</span>
-							</td>
-							<td>
-								<span *ngIf="med.estado === 'Activo'" class="text-green-600 font-bold text-xs">● Activo</span>
-								<span *ngIf="med.estado !== 'Activo'" class="text-gray-400 font-bold text-xs">● Inactivo</span>
-							</td>
-						</tr>
-					</ng-template>
-				</p-table>
-			</p-tabpanel>
 		</p-tabpanels>
 	</p-tabs>
 
@@ -144,3 +187,71 @@
 		></p-button>
 	</div>
 </div>
+
+<p-dialog
+	header="Registrar Nuevo Terreno"
+	[(visible)]="mostrarModalTerreno"
+	[modal]="true"
+	[style]="{ width: '450px' }"
+	[draggable]="false"
+	[resizable]="false"
+>
+	<form [formGroup]="terrenoForm" class="flex flex-col gap-4 mt-2">
+		<div class="field flex flex-col gap-2">
+			<span class="font-bold text-sm">Barrio / Sector *</span>
+			<p-select
+				[options]="listaBarrios"
+				formControlName="barrio"
+				optionLabel="nombre"
+				optionValue="nombre"
+				placeholder="Seleccione el sector"
+				appendTo="body"
+				[style]="{ width: '100%' }"
+				[showClear]="true"
+				emptyMessage="No hay barrios activos"
+			>
+			</p-select>
+			<small
+				*ngIf="terrenoForm.get('barrio')?.invalid && terrenoForm.get('barrio')?.touched"
+				class="text-red-500 text-xs"
+			>
+				El barrio es obligatorio.
+			</small>
+		</div>
+
+		<div class="field flex flex-col gap-2">
+			<span class="font-bold text-sm">Dirección / Referencia *</span>
+			<input pInputText formControlName="direccion" placeholder="Ej: Frente a la escuela, casa verde" class="w-full" />
+			<small
+				*ngIf="terrenoForm.get('direccion')?.invalid && terrenoForm.get('direccion')?.touched"
+				class="text-red-500 text-xs"
+			>
+				La dirección es obligatoria.
+			</small>
+		</div>
+
+		<div class="field flex items-center justify-between bg-gray-50 p-3 rounded-lg border border-gray-200">
+			<div class="flex flex-col">
+				<span class="font-bold text-sm text-gray-800">¿Tiene Medidor?</span>
+				<span class="text-xs text-gray-500">Activar si el terreno posee medidor de agua.</span>
+			</div>
+			<p-toggleswitch formControlName="tiene_medidor"></p-toggleswitch>
+		</div>
+
+		<div *ngIf="terrenoForm.get('tiene_medidor')?.value" class="field flex flex-col gap-2 animate-fade-in">
+			<span class="font-bold text-sm text-blue-700">Código del Medidor *</span>
+			<input pInputText formControlName="codigo_medidor" placeholder="Ej: MED-2024-001" class="w-full" />
+			<small
+				*ngIf="terrenoForm.get('codigo_medidor')?.invalid && terrenoForm.get('codigo_medidor')?.touched"
+				class="text-red-500 text-xs"
+			>
+				El código es obligatorio si hay medidor.
+			</small>
+		</div>
+	</form>
+
+	<ng-template pTemplate="footer">
+		<p-button label="Cancelar" icon="pi pi-times" [text]="true" (onClick)="mostrarModalTerreno = false"></p-button>
+		<p-button label="Guardar Propiedad" icon="pi pi-check" [loading]="false" (onClick)="guardarTerreno()"></p-button>
+	</ng-template>
+</p-dialog>

--- a/src/app/dashboard/pages/socios/detalle-socio/detalle-socio.component.ts
+++ b/src/app/dashboard/pages/socios/detalle-socio/detalle-socio.component.ts
@@ -3,7 +3,10 @@ import { CommonModule } from '@angular/common';
 import { ActivatedRoute, Router } from '@angular/router';
 import { catchError, of, tap } from 'rxjs';
 
-// PrimeNG
+// ✅ IMPORTS DE ANGULAR FORMS
+import { ReactiveFormsModule, FormBuilder, FormGroup, Validators } from '@angular/forms';
+
+// ✅ IMPORTS DE PRIMENG
 import { ButtonModule } from 'primeng/button';
 import { TagModule } from 'primeng/tag';
 import { TableModule } from 'primeng/table';
@@ -13,9 +16,16 @@ import { ToastModule } from 'primeng/toast';
 import { MessageService } from 'primeng/api';
 import { DividerModule } from 'primeng/divider';
 import { SkeletonModule } from 'primeng/skeleton';
+import { TooltipModule } from 'primeng/tooltip';
+import { DialogModule } from 'primeng/dialog'; // Para el Modal
+import { SelectModule } from 'primeng/select';
+import { InputTextModule } from 'primeng/inputtext'; // Para textos
+import { ToggleSwitchModule } from 'primeng/toggleswitch';
 
 // Servicios y Modelos
+import { TerrenoService } from '../../../../core/services/terreno.service';
 import { SocioService } from '../../../../core/services/socio.service';
+import { BarriosService } from '../../../../core/services/barrios.service'; // ✅ Asegúrate que la ruta sea correcta
 import { Socio } from '../../../../core/models/socio.interface';
 
 @Component({
@@ -23,6 +33,7 @@ import { Socio } from '../../../../core/models/socio.interface';
 	standalone: true,
 	imports: [
 		CommonModule,
+		ReactiveFormsModule, // ✅ Necesario para formularios
 		ButtonModule,
 		TagModule,
 		TableModule,
@@ -31,48 +42,144 @@ import { Socio } from '../../../../core/models/socio.interface';
 		ToastModule,
 		DividerModule,
 		SkeletonModule,
+		TooltipModule,
+		DialogModule, // ✅
+		SelectModule, // ✅
+		InputTextModule, // ✅
+		ToggleSwitchModule, // ✅
 	],
 	providers: [MessageService],
 	templateUrl: './detalle-socio.component.html',
 })
 export class DetalleSocioComponent implements OnInit {
+	// Inyecciones
 	private route = inject(ActivatedRoute);
 	private router = inject(Router);
 	private socioService = inject(SocioService);
 	private messageService = inject(MessageService);
-
+	private fb = inject(FormBuilder); // ✅ Para crear el formulario
+	private barriosService = inject(BarriosService); // ✅ Para cargar lista de barrios
+	private terrenoService = inject(TerrenoService);
+	// Datos del Socio
 	socioId!: number;
 	socio: Socio | null = null;
 	isLoading = true;
 
-	// MOCK: Datos simulados de pagos (Simulando respuesta del backend)
+	// Lógica del Modal de Terrenos
+	mostrarModalTerreno = false;
+	terrenoForm!: FormGroup;
+	listaBarrios: any[] = [];
+	terrenos: any[] = []; // Tabla local de terrenos
+
+	// MOCK: Datos simulados de pagos
 	historialPagos = [
 		{ id: 1, mes: 'Noviembre 2025', monto: 3.5, estado: 'PAGADO', fecha_pago: '2025-11-05' },
 		{ id: 2, mes: 'Diciembre 2025', monto: 5.0, estado: 'PENDIENTE', fecha_pago: null },
 		{ id: 3, mes: 'Multa Minga Dic', monto: 10.0, estado: 'PENDIENTE', fecha_pago: null },
 	];
 
-	// MOCK: Datos simulados de medidores
-	misMedidores = [
-		{ codigo: 'MED-004', ubicacion: 'Casa Principal', tipo: 'Físico', estado: 'Activo' },
-		{ codigo: 'MED-102', ubicacion: 'Terreno Baldío', tipo: 'Tarifa Fija', estado: 'Inactivo' },
-	];
-
 	ngOnInit(): void {
+		// 1. Inicializamos el formulario y cargamos catálogos
+		this.initForm();
+		this.cargarBarrios();
+
+		// 2. Cargamos el socio de la URL
 		this.route.paramMap.subscribe((params) => {
 			const id = params.get('id');
 			if (id) {
 				this.socioId = +id;
 				this.cargarSocio();
+				this.cargarTerrenos();
 			} else {
 				this.volver();
 			}
 		});
 	}
 
+	// --- LÓGICA DEL FORMULARIO ---
+	initForm() {
+		this.terrenoForm = this.fb.group({
+			barrio: [null, [Validators.required]],
+			direccion: ['', [Validators.required]],
+			tiene_medidor: [false],
+			codigo_medidor: [''],
+		});
+
+		// Suscripción: Si activa el medidor, el código se vuelve obligatorio
+		this.terrenoForm.get('tiene_medidor')?.valueChanges.subscribe((tieneMedidor) => {
+			const codigoControl = this.terrenoForm.get('codigo_medidor');
+			if (tieneMedidor) {
+				codigoControl?.setValidators([Validators.required]);
+			} else {
+				codigoControl?.clearValidators();
+				codigoControl?.setValue('');
+			}
+			codigoControl?.updateValueAndValidity();
+		});
+	}
+	cargarTerrenos() {
+		this.terrenoService.getTerrenosPorSocio(this.socioId).subscribe({
+			next: (data) => {
+				this.terrenos = data;
+			},
+			error: (err) => console.error('Error cargando terrenos', err),
+		});
+	}
+	cargarBarrios() {
+		this.barriosService.getBarrios().subscribe({
+			next: (data) => {
+				// Solo mostramos barrios activos para asignar a terrenos
+				this.listaBarrios = data.filter((b) => b.activo);
+			},
+			error: () => console.warn('No se pudieron cargar los barrios'),
+		});
+	}
+
+	// --- ACCIONES DEL MODAL ---
+	abrirModalTerreno() {
+		this.terrenoForm.reset({ tiene_medidor: false });
+		this.mostrarModalTerreno = true;
+	}
+
+	guardarTerreno() {
+		if (this.terrenoForm.invalid) {
+			this.terrenoForm.markAllAsTouched();
+			return;
+		}
+
+		// Preparamos los datos para enviar al Backend
+		const datosParaEnviar = {
+			...this.terrenoForm.value,
+			socio: this.socioId, // ⚠️ IMPORTANTE: Hay que decirle de quién es el terreno
+
+			// NOTA: Revisa con tu backend si quiere el NOMBRE ('Alpamalag') o el ID (1) del barrio.
+			// Si tu dropdown tiene optionValue="nombre", enviará el nombre.
+		};
+
+		this.terrenoService.createTerreno(datosParaEnviar).subscribe({
+			next: (_terrenoCreado) => {
+				this.messageService.add({
+					severity: 'success',
+					summary: 'Éxito',
+					detail: 'Propiedad registrada correctamente',
+				});
+
+				// Cerramos el modal
+				this.mostrarModalTerreno = false;
+
+				// Recargamos la lista para ver el nuevo terreno
+				this.cargarTerrenos();
+			},
+			error: (err) => {
+				console.error(err);
+				this.messageService.add({ severity: 'error', summary: 'Error', detail: 'No se pudo guardar el terreno.' });
+			},
+		});
+	}
+
+	// --- LÓGICA EXISTENTE ---
 	cargarSocio(): void {
 		this.isLoading = true;
-		// Llamamos al servicio para obtener el socio real por ID
 		this.socioService
 			.getSocioById(this.socioId)
 			.pipe(
@@ -87,7 +194,6 @@ export class DetalleSocioComponent implements OnInit {
 						detail: `No se pudo cargar: ${err.message}`,
 					});
 					this.isLoading = false;
-					// Volver atrás si falla
 					setTimeout(() => this.volver(), 2000);
 					return of(null);
 				}),


### PR DESCRIPTION
## Descripción
Se implementó la interfaz de usuario para la **Gestión de Terrenos y Propiedades** dentro del Perfil del Socio.
Este módulo permite registrar terrenos asociados a un socio y definir si poseen medidor o solo acometida.

## Cambios Realizados (Frontend Only)
* **Nueva Sección en Perfil:** Se agregó el bloque "Propiedades Registradas" debajo de los datos personales.
* **Modal de Registro:** Formulario emergente (`p-dialog`) con validaciones reactivas:
    * Selección de Barrio (Dropdown cargado desde el servicio).
    * Switch "¿Tiene Medidor?" que habilita/deshabilita el campo de código.
* **Lógica Visual:**
    * Tabla de terrenos con estados visuales (Tags informativos).
    * Simulación de guardado en memoria (listo para conectar a API).

## Pendiente (Para Backend)
* Se requiere el endpoint `POST /api/v1/terrenos/` y `GET /api/v1/terrenos/?socio_id=X` para persistir los datos.