### PR TITLE
feat: boton eliminar terreno y estilos visuales acciones tabla

### DIFF
--- a/src/app/dashboard/pages/socios/detalle-socio/detalle-socio.component.html
+++ b/src/app/dashboard/pages/socios/detalle-socio/detalle-socio.component.html
@@ -1,5 +1,5 @@
 <p-toast></p-toast>
-
+<p-confirmDialog></p-confirmDialog>
 <div *ngIf="isLoading" class="card p-6 bg-white rounded-xl shadow-sm border border-gray-100 animate-pulse">
 	<div class="flex gap-4 mb-6">
 		<p-skeleton shape="circle" size="5rem"></p-skeleton>
@@ -118,16 +118,31 @@
 						</td>
 
 						<td class="text-center">
-							<p-button
-								icon="pi pi-pencil"
-								[text]="true"
-								[rounded]="true"
-								severity="secondary"
-								pTooltip="Editar terreno"
-								tooltipPosition="top"
-								(onClick)="editarTerreno(terreno)"
-							>
-							</p-button>
+							<div class="flex justify-center gap-2 min-w-[90px]">
+								<p-button
+									icon="pi pi-pencil"
+									[rounded]="true"
+									[outlined]="true"
+									severity="info"
+									size="small"
+									pTooltip="Editar terreno"
+									tooltipPosition="top"
+									(onClick)="editarTerreno(terreno)"
+								>
+								</p-button>
+
+								<p-button
+									icon="pi pi-trash"
+									severity="danger"
+									[rounded]="true"
+									[outlined]="true"
+									size="small"
+									pTooltip="Eliminar terreno"
+									tooltipPosition="top"
+									(onClick)="eliminarTerreno(terreno)"
+								>
+								</p-button>
+							</div>
 						</td>
 					</tr>
 				</ng-template>

--- a/src/app/dashboard/pages/socios/detalle-socio/detalle-socio.component.ts
+++ b/src/app/dashboard/pages/socios/detalle-socio/detalle-socio.component.ts
@@ -27,6 +27,8 @@ import { TerrenoService } from '../../../../core/services/terreno.service';
 import { SocioService } from '../../../../core/services/socio.service';
 import { BarriosService } from '../../../../core/services/barrios.service'; // ✅ Asegúrate que la ruta sea correcta
 import { Socio } from '../../../../core/models/socio.interface';
+import { ConfirmationService } from 'primeng/api';
+import { ConfirmDialogModule } from 'primeng/confirmdialog';
 
 @Component({
 	selector: 'app-detalle-socio',
@@ -47,6 +49,7 @@ import { Socio } from '../../../../core/models/socio.interface';
 		SelectModule, // ✅
 		InputTextModule, // ✅
 		ToggleSwitchModule, // ✅
+		ConfirmDialogModule,
 	],
 	providers: [MessageService],
 	templateUrl: './detalle-socio.component.html',
@@ -60,6 +63,7 @@ export class DetalleSocioComponent implements OnInit {
 	private fb = inject(FormBuilder); // ✅ Para crear el formulario
 	private barriosService = inject(BarriosService); // ✅ Para cargar lista de barrios
 	private terrenoService = inject(TerrenoService);
+	private confirmationService = inject(ConfirmationService);
 	// Datos del Socio
 	socioId!: number;
 	socio: Socio | null = null;
@@ -243,7 +247,31 @@ export class DetalleSocioComponent implements OnInit {
 
 		this.mostrarModalTerreno = true;
 	}
+	eliminarTerreno(terreno: any) {
+		this.confirmationService.confirm({
+			message: `¿Estás seguro de eliminar el terreno en "${terreno.direccion}"?`,
+			header: 'Confirmar Eliminación',
+			icon: 'pi pi-exclamation-triangle',
+			acceptLabel: 'Sí, eliminar',
+			acceptButtonStyleClass: 'p-button-danger',
 
+			accept: () => {
+				this.terrenoService.deleteTerreno(terreno.id).subscribe({
+					next: () => {
+						this.messageService.add({ severity: 'success', summary: 'Éxito', detail: 'Terreno eliminado.' });
+						this.cargarTerrenos(); // Recargar la tabla
+					},
+					error: (_err) => {
+						this.messageService.add({
+							severity: 'error',
+							summary: 'Error',
+							detail: 'No se pudo eliminar (puede tener lecturas asociadas).',
+						});
+					},
+				});
+			},
+		});
+	}
 	volver(): void {
 		this.router.navigate(['/dashboard/socios']);
 	}


### PR DESCRIPTION
Esta solicitud de extracción añade la posibilidad de eliminar una propiedad ("terreno") de la vista de detalles del miembro, incluyendo un cuadro de diálogo de confirmación para evitar eliminaciones accidentales. Además, mejora la interfaz de usuario e integra los módulos y servicios de PrimeNG necesarios para esta funcionalidad.

Función: Eliminación de propiedades con confirmación

Se añadió un botón de eliminación (icono de papelera) junto a cada propiedad en la tabla de propiedades registradas, lo que permite a los usuarios iniciar la eliminación.
Se implementó un cuadro de diálogo de confirmación (p-confirmDialog) que aparece cuando un usuario intenta eliminar una propiedad, lo que garantiza que los usuarios confirmen su acción antes de proceder a la eliminación.
Se integró ConfirmationService de PrimeNG y se inyectó en el componente para gestionar la lógica de confirmación.
Se añadió el método eliminarTerreno, que utiliza el cuadro de diálogo de confirmación y llama a TerrenoService para eliminar la propiedad. Proporciona retroalimentación al usuario mediante mensajes de notificación y actualiza la lista de propiedades si la eliminación se realiza correctamente.
Mejoras de la interfaz de usuario

Se actualizó el estilo del botón de edición y se agruparon los botones de edición y eliminación para una mejor coherencia del diseño en la tabla de propiedades.